### PR TITLE
Update README.md to not assume gender 🙂

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Minimum required xml markup for the browserconfig.xml file is as follows:
 
 > 📖 [HTML Reference](http://htmlreference.io/)
 
-* [ ] **Error pages:** ![High][high_img] Error 404 page and 5xx exist. Remember that the 5xx error page needs to have his CSS integrated (no external call on the current server).
+* [ ] **Error pages:** ![High][high_img] Error 404 page and 5xx exist. Remember that the 5xx error pages need to have their CSS integrated (no external call on the current server).
 
 * [ ] **Noopener:** ![Medium][medium_img] In case you are using external links with `target="_blank"`, your link should have a `rel="noopener"` attribute to prevent tab nabbing. If you need to support older versions of Firefox, use `rel="noopener noreferrer"`.
 


### PR DESCRIPTION
The description for Error pages referred to 5xx error pages as `his` when in fact they have no gender.